### PR TITLE
FIX for CraftingStation. NBTData Items work properly now

### DIFF
--- a/src/main/java/mcjty/rftoolscontrol/blocks/craftingstation/CraftingStationTileEntity.java
+++ b/src/main/java/mcjty/rftoolscontrol/blocks/craftingstation/CraftingStationTileEntity.java
@@ -366,7 +366,7 @@ public class CraftingStationTileEntity extends GenericTileEntity implements Defa
         return canPlayerAccess(player);
     }
 
-    private int findItem(String itemName, int meta) {
+    private int findItem(String itemName, int meta, String nbtString) {
         int index = 0;
         for (BlockPos p : processorList) {
             TileEntity te = worldObj.getTileEntity(p);
@@ -375,7 +375,9 @@ public class CraftingStationTileEntity extends GenericTileEntity implements Defa
                 List<ItemStack> items = new ArrayList<>();
                 processor.getCraftableItems(items);
                 for (ItemStack item : items) {
-                    if (item.getItemDamage() == meta && itemName.equals(item.getItem().getRegistryName().toString())) {
+                    if (item.hasTagCompound()) {
+                    	if (nbtString.equalsIgnoreCase(item.serializeNBT().toString())) return index;
+                    } else if (item.getItemDamage() == meta && itemName.equals(item.getItem().getRegistryName().toString())) {
                         return index;
                     }
                     index++;
@@ -396,7 +398,8 @@ public class CraftingStationTileEntity extends GenericTileEntity implements Defa
         if (CMD_REQUEST.equals(command)) {
             String itemName = args.get("item").getString();
             int meta = args.get("meta").getInteger();
-            int index = findItem(itemName, meta);
+            String nbtString = args.get("nbtData").getString();
+            int index = findItem(itemName, meta, nbtString);
             if (index == -1) {
                 return true;
             }

--- a/src/main/java/mcjty/rftoolscontrol/blocks/craftingstation/GuiCraftingStation.java
+++ b/src/main/java/mcjty/rftoolscontrol/blocks/craftingstation/GuiCraftingStation.java
@@ -247,6 +247,7 @@ public class GuiCraftingStation extends GenericGuiContainer<CraftingStationTileE
         sendServerCommand(RFToolsCtrlMessages.INSTANCE, CraftingStationTileEntity.CMD_REQUEST,
                 new Argument("item", stack.getItem().getRegistryName().toString()),
                 new Argument("meta", stack.getItemDamage()),
+                new Argument("nbtData", stack.hasTagCompound() ? stack.serializeNBT().toString() : ""),
                 new Argument("amount", amount));
     }
 


### PR DESCRIPTION
I have found that the problem for Crafting some items is NBT data.

I have added a parameter for the NBT of the ItemStack selected by the user, and also added logic to check for equality only when the item in the crafting table has nbt data. For non nbt data it should work the same.

I hope you can merge and release soon :)