### PR TITLE
refix METADATA on Crafting Stations.

### DIFF
--- a/src/main/java/mcjty/rftoolscontrol/blocks/processor/ProcessorTileEntity.java
+++ b/src/main/java/mcjty/rftoolscontrol/blocks/processor/ProcessorTileEntity.java
@@ -844,11 +844,19 @@ public class ProcessorTileEntity extends GenericEnergyReceiverTileEntity impleme
     }
 
     private ItemStack findCraftingCard(IItemHandler handler, ItemStack craftResult) {
+    	String resultNBT = "";
+        if (craftResult.hasTagCompound()) {
+        	resultNBT = craftResult.serializeNBT().toString();
+        }
         for (int j = 0 ; j < handler.getSlots() ; j++) {
             ItemStack s = handler.getStackInSlot(j);
             if (ItemStackTools.isValid(s) && s.getItem() == ModItems.craftingCardItem) {
                 ItemStack result = CraftingCardItem.getResult(s);
-                if (ItemStackTools.isValid(result) && result.isItemEqual(craftResult)) {
+                if (craftResult.hasTagCompound()) {
+                    if (result.hasTagCompound() && resultNBT.equalsIgnoreCase(result.serializeNBT().toString())) {
+                        return s;
+                    }
+                } else if (ItemStackTools.isValid(result) && result.isItemEqual(craftResult)) {
                     return s;
                 }
             }

--- a/src/main/java/mcjty/rftoolscontrol/commands/ProgramCommand.java
+++ b/src/main/java/mcjty/rftoolscontrol/commands/ProgramCommand.java
@@ -29,7 +29,10 @@ public class ProgramCommand extends CompatCommandBase {
     @Override
     public String getName() {
         return "rfctrl";
-    }
+    }  
+    public String getCommandName() { 
+        return "rfctrl"; 
+    } 
 
     @Override
     public String getUsage(ICommandSender sender) {


### PR DESCRIPTION
Previously fixed in a sense that the crafting detect nbt data on selected items. This time the fix look for nbt data on the results of crafting templates