### PR TITLE
use forge tag check instead of string matching

### DIFF
--- a/src/main/java/mcjty/rftoolscontrol/blocks/processor/ProcessorTileEntity.java
+++ b/src/main/java/mcjty/rftoolscontrol/blocks/processor/ProcessorTileEntity.java
@@ -846,18 +846,13 @@ public class ProcessorTileEntity extends GenericEnergyReceiverTileEntity impleme
     }
 
     private ItemStack findCraftingCard(IItemHandler handler, ItemStack craftResult) {
-    	String resultNBT = "";
-        if (craftResult.hasTagCompound()) {
-        	resultNBT = craftResult.serializeNBT().toString();
-        }
         for (int j = 0 ; j < handler.getSlots() ; j++) {
             ItemStack s = handler.getStackInSlot(j);
             if (ItemStackTools.isValid(s) && s.getItem() == ModItems.craftingCardItem) {
                 ItemStack result = CraftingCardItem.getResult(s);
-
                 if (ItemStackTools.isValid(result) && result.isItemEqual(craftResult)) {
                     if (craftResult.hasTagCompound()) {
-                        if (resultNBT.equalsIgnoreCase(result.serializeNBT().toString())) {
+                        if (ItemStack.areItemsEqual(craftResult, result)) {
                             return s;
                         }
                     } else {

--- a/src/main/java/mcjty/rftoolscontrol/logic/InventoryTools.java
+++ b/src/main/java/mcjty/rftoolscontrol/logic/InventoryTools.java
@@ -80,15 +80,7 @@ public class InventoryTools {
     public static boolean isEqualAdvanced(ItemStack itemMatcher, ItemStack stack, boolean strictnbt) {
         if (ItemStackTools.isValid(stack) && ItemStack.areItemsEqual(stack, itemMatcher)) {
             if (strictnbt) {
-                if (itemMatcher.hasTagCompound() || stack.hasTagCompound()) {
-                    String t1 = itemMatcher.serializeNBT().toString();
-                    String t2 = stack.serializeNBT().toString();
-                    if (t1.equalsIgnoreCase(t2)) {
-                        return true;
-                    }
-                } else {
-                    return true;
-                }
+                return (!itemMatcher.hasTagCompound() || ItemStack.areItemStackTagsEqual(stack, itemMatcher));
             } else {
                 return true;
             }


### PR DESCRIPTION
Solves processor not actually pulling an nbt-containing item into internal inventory during getIngredients using an nbt-sensitive crafting card.