### PR TITLE
fix: crafting station picking wrong recipe

### DIFF
--- a/src/main/java/mcjty/rftoolscontrol/blocks/craftingstation/CraftingStationTileEntity.java
+++ b/src/main/java/mcjty/rftoolscontrol/blocks/craftingstation/CraftingStationTileEntity.java
@@ -390,14 +390,11 @@ public class CraftingStationTileEntity extends GenericTileEntity implements Defa
                 ItemStackList items = ItemStackList.create();
                 processor.getCraftableItems(items);
                 for (ItemStack item : items) {
-                    if (item.getItemDamage() == meta && itemName.equals(item.getItem().getRegistryName().toString())) {
-                        if (item.hasTagCompound()) {
-                            if (nbtString.equalsIgnoreCase(item.serializeNBT().toString())) {
-                                return index;
-                            }
-                        } else {
-                            return index;
-                        }
+                    if (item.getItemDamage() == meta &&
+                            itemName.equals(item.getItem().getRegistryName().toString()) &&
+                            (item.hasTagCompound() ? item.serializeNBT().toString() : "").equalsIgnoreCase(nbtString)
+                    ) {
+                        return index;
                     }
                     index++;
                 }


### PR DESCRIPTION
This fix an bug that crafting station picking wrong recipe.

Bug details:
As a minecraft player 
WHEN In the crafting station, item A and item B has same name, and meta data
AND item A has no NBT data but B has NBT data
AND item B is right after item A
WHEN I request item B
THEN findItem will give the index of item A since A has no NBT data
AND crafting station will send craft request with item A



Change tested. Issue fixed.

![image](https://user-images.githubusercontent.com/1845937/86290026-09f93300-bc30-11ea-8b14-21fb1a46bcaa.png)
