### PR TITLE
Updated the Workbench recipe to use tags

### DIFF
--- a/src/main/resources/assets/rftoolscontrol/recipes/workbench.json
+++ b/src/main/resources/assets/rftoolscontrol/recipes/workbench.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "C": {
-      "item": "minecraft:chest"
+      "tag": "forge:chests/wooden"
     },
     "T": {
       "item": "minecraft:crafting_table"


### PR DESCRIPTION
Replaced `"minecraft:chest"` with `"forge:chests/wooden"`