### PR TITLE
Updated Workbench recipe to use tags

### DIFF
--- a/src/generated/resources/data/rftoolscontrol/recipes/workbench.json
+++ b/src/generated/resources/data/rftoolscontrol/recipes/workbench.json
@@ -10,7 +10,7 @@
       "item": "minecraft:crafting_table"
     },
     "X": {
-      "item": "minecraft:chest"
+      "tag": "forge:chests/wooden"
     },
     "F": {
       "item": "rftoolsbase:machine_frame"


### PR DESCRIPTION
Replaced `"minecraft:chest"` with `"forge:chests/wooden"`